### PR TITLE
Add i18n consideration checkbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-CR-review.yml
+++ b/.github/ISSUE_TEMPLATE/request-CR-review.yml
@@ -25,6 +25,13 @@ body:
       placeholder: https://www.w3.org/TR/...
     validations:
       required: true
+  - type: checkboxes
+    id: spec-i18n-section
+    attributes:
+      label: Does your specification include an Internationalization Considerations section?
+      description: If your specification includes an [Internationalization Considerations section](https://www.w3.org/TR/international-specs/#I18N_Considerations), mark this checkbox.
+      options:
+        - label: My specification includes an Internationalization Considerations section
 
   - type: input
     id: date

--- a/.github/ISSUE_TEMPLATE/request-a-self-review-check.yml
+++ b/.github/ISSUE_TEMPLATE/request-a-self-review-check.yml
@@ -23,6 +23,13 @@ body:
       placeholder: https://www.w3.org/TR/...
     validations:
       required: true
+  - type: checkboxes
+    id: spec-i18n-section
+    attributes:
+      label: Does your specification include an Internationalization Considerations section?
+      description: If your specification includes an [Internationalization Considerations section](https://www.w3.org/TR/international-specs/#I18N_Considerations), mark this checkbox.
+      options:
+        - label: My specification includes an Internationalization Considerations section
   - type: input
     id: repo-issue
     attributes:

--- a/.github/ISSUE_TEMPLATE/request-fpwd-review.yml
+++ b/.github/ISSUE_TEMPLATE/request-fpwd-review.yml
@@ -25,6 +25,13 @@ body:
       placeholder: https://www.w3.org/TR/...
     validations:
       required: true
+  - type: checkboxes
+    id: spec-i18n-section
+    attributes:
+      label: Does your specification include an Internationalization Considerations section?
+      description: If your specification includes an [Internationalization Considerations section](https://www.w3.org/TR/international-specs/#I18N_Considerations), mark this checkbox.
+      options:
+        - label: My specification includes an Internationalization Considerations section
   - type: input
     id: date
     attributes:

--- a/.github/ISSUE_TEMPLATE/request-prior-to-CR.yml
+++ b/.github/ISSUE_TEMPLATE/request-prior-to-CR.yml
@@ -25,6 +25,13 @@ body:
       placeholder: https://www.w3.org/TR/...
     validations:
       required: true
+  - type: checkboxes
+    id: spec-i18n-section
+    attributes:
+      label: Does your specification include an Internationalization Considerations section?
+      description: If your specification includes an [Internationalization Considerations section](https://www.w3.org/TR/international-specs/#I18N_Considerations), mark this checkbox.
+      options:
+        - label: My specification includes an Internationalization Considerations section
 
   - type: input
     id: date

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.yml
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.yml
@@ -25,6 +25,13 @@ body:
       placeholder: https://www.w3.org/TR/...
     validations:
       required: true
+  - type: checkboxes
+    id: spec-i18n-section
+    attributes:
+      label: Does your specification include an Internationalization Considerations section?
+      description: If your specification includes an [Internationalization Considerations section](https://www.w3.org/TR/international-specs/#I18N_Considerations), mark this checkbox.
+      options:
+        - label: My specification includes an Internationalization Considerations section
   - type: input
     id: date
     attributes:

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.yml
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.yml
@@ -53,7 +53,7 @@ body:
     id: self
     attributes:
       label: Pointer to any explainer for the spec.
-       placeholder: Add a URL
+      placeholder: Add a URL
   - type: textarea
     attributes:
       label: Other comments

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.yml
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.yml
@@ -42,19 +42,19 @@ body:
     attributes:
       label: Please point to the results of your own self-review (see https://w3c.github.io/i18n-drafts/techniques/shortchecklist).
       description: If so, add the date here
-   - type: input
+  - type: input
     id: filing
     attributes:
       label: Where and how should the i18n WG raise issues? (We prefer to use the issue list in your document's repo.)
       placeholder: Link to the location
     validations:
       required: true
-   - type: input
+  - type: input
     id: self
     attributes:
       label: Pointer to any explainer for the spec.
        placeholder: Add a URL
- - type: textarea
+  - type: textarea
     attributes:
       label: Other comments
 

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.yml
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.yml
@@ -38,7 +38,7 @@ body:
       label: Do you need a reply by a particular date?
       description: If so, add the date here
   - type: input
-    id: self
+    id: self-review-issue
     attributes:
       label: Please point to the results of your own self-review (see https://w3c.github.io/i18n-drafts/techniques/shortchecklist).
       description: If so, add the date here
@@ -50,7 +50,7 @@ body:
     validations:
       required: true
   - type: input
-    id: self
+    id: self-explainer
     attributes:
       label: Pointer to any explainer for the spec.
       placeholder: Add a URL

--- a/.github/ISSUE_TEMPLATE/review-other-doc.yml
+++ b/.github/ISSUE_TEMPLATE/review-other-doc.yml
@@ -25,6 +25,13 @@ body:
       placeholder: https://www.w3.org/TR/...
     validations:
       required: true
+  - type: checkboxes
+    id: spec-i18n-section
+    attributes:
+      label: Does your specification include an Internationalization Considerations section?
+      description: If your specification includes an [Internationalization Considerations section](https://www.w3.org/TR/international-specs/#I18N_Considerations), mark this checkbox.
+      options:
+        - label: My specification includes an Internationalization Considerations section
 
   - type: input
     id: date


### PR DESCRIPTION
Added as checkbox. 

- It seems there is no option to add checkbox as a child of other input field, e.g. attached sub-item to specification URL input box. So added at right below the input field of specification URL.
- fixed several markdown syntax error at request-review-for-a-fpwd.yml (should be a separated PR??)
- description is linked to a hash URL used for current editors' draft at github.io. so, hash will not be active until next publication to /TR/ of specdev.
- check form sample at e.g. https://github.com/himorin/i18n-request/blob/add-i18n-consideration/.github/ISSUE_TEMPLATE/request-CR-review.yml